### PR TITLE
Javaughn Stephenson Submission Task 3

### DIFF
--- a/challenge-3/bug-fixing-submissions/README.md
+++ b/challenge-3/bug-fixing-submissions/README.md
@@ -12,3 +12,16 @@ Each participant should:
 3. Optional: Add a test/assertion or output sample proving it works correctly
 
 Place the corrected code of your choosing in a folder here, naming the folder using the format, first_name-last_name.
+
+## Comment
+
+The bug was:
+1.  Line 6: Class.forName("writers." + className); --- The writer class was not in a package called "writers"
+2. To accurately get the naming convention of the class, there can be other writers
+
+How Identify:
+1. Checking error messages
+
+Why fix is correct:
+1. Get rid of the "writers." before the className as its not in a package
+2. When the name of the class is wrong it throws NoClassDefFoundError, we can catch that and extract the correct name from the error message and then try to get the correct class name

--- a/challenge-3/bug-fixing-submissions/README.md
+++ b/challenge-3/bug-fixing-submissions/README.md
@@ -12,16 +12,3 @@ Each participant should:
 3. Optional: Add a test/assertion or output sample proving it works correctly
 
 Place the corrected code of your choosing in a folder here, naming the folder using the format, first_name-last_name.
-
-## Comment
-
-The bug was:
-1.  Line 6: Class.forName("writers." + className); --- The writer class was not in a package called "writers"
-2. To accurately get the naming convention of the class, there can be other writers
-
-How Identify:
-1. Checking error messages
-
-Why fix is correct:
-1. Get rid of the "writers." before the className as its not in a package
-2. When the name of the class is wrong it throws NoClassDefFoundError, we can catch that and extract the correct name from the error message and then try to get the correct class name

--- a/challenge-3/bug-fixing-submissions/javaughn_stephenson/DataWriter.java
+++ b/challenge-3/bug-fixing-submissions/javaughn_stephenson/DataWriter.java
@@ -1,0 +1,3 @@
+public interface DataWriter {
+    void write(String data);
+}

--- a/challenge-3/bug-fixing-submissions/javaughn_stephenson/JavaBugFixing.java
+++ b/challenge-3/bug-fixing-submissions/javaughn_stephenson/JavaBugFixing.java
@@ -1,0 +1,7 @@
+
+public class JavaBugFixing {
+    public static void main(String[] args) {
+        DataWriter writer = WriterFactory.getWriter("mysql");
+        writer.write("Test data");
+    }
+}

--- a/challenge-3/bug-fixing-submissions/javaughn_stephenson/MySQLWriter.java
+++ b/challenge-3/bug-fixing-submissions/javaughn_stephenson/MySQLWriter.java
@@ -1,0 +1,6 @@
+
+public class MySQLWriter implements DataWriter {
+    public void write(String data) {
+        System.out.println("Writing to MySQL: " + data);
+    }
+}

--- a/challenge-3/bug-fixing-submissions/javaughn_stephenson/README.md
+++ b/challenge-3/bug-fixing-submissions/javaughn_stephenson/README.md
@@ -1,0 +1,27 @@
+## Bug Fixing Submissions
+
+Each participant should:
+
+1. Submit the corrected code
+
+2. Comment a short explanation of:
+   - What the bug was
+   - How they identified it
+   - Why their fix is correct
+
+3. Optional: Add a test/assertion or output sample proving it works correctly
+
+Place the corrected code of your choosing in a folder here, naming the folder using the format, first_name-last_name.
+
+## Comment
+
+The bug was:
+1.  Line 6: Class.forName("writers." + className); --- The writer class was not in a package called "writers"
+2. To accurately get the naming convention of the class, there can be other writers
+
+How Identify:
+1. Checking error messages
+
+Why fix is correct:
+1. Get rid of the "writers." before the className as its not in a package
+2. When the name of the class is wrong it throws NoClassDefFoundError, we can catch that and extract the correct name from the error message and then try to get the correct class name

--- a/challenge-3/bug-fixing-submissions/javaughn_stephenson/WriterFactory.java
+++ b/challenge-3/bug-fixing-submissions/javaughn_stephenson/WriterFactory.java
@@ -1,0 +1,28 @@
+public class WriterFactory {
+    public static DataWriter getWriter(String type) {
+        try {
+            String className = type.substring(0, 1).toUpperCase() + type.substring(1).toLowerCase() + "Writer";
+            Class<?> clazz = Class.forName(className);
+            return (DataWriter) clazz.getDeclaredConstructor().newInstance();
+        }
+        catch (NoClassDefFoundError e) {
+            return tryNewName(e.getMessage());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private static DataWriter tryNewName(String name) {
+        int length = name.length() - 1;
+        int index = name.indexOf(":") + 2;
+        String newClassName = name.substring(index,  length);
+        try{
+            Class<?> clazz = Class.forName(newClassName);
+            return (DataWriter) clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
The bug was:
1.  Line 6: Class.forName("writers." + className); --- The writer class was not in a package called "writers"
2. To accurately get the naming convention of the class, there can be other writers

How Identify:
1. Checking error messages

Why fix is correct:
1. Get rid of the "writers." before the className as its not in a package
2. When the name of the class is wrong it throws NoClassDefFoundError, we can catch that and extract the correct name from the error message and then try to get the correct class name